### PR TITLE
Data loading fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Created by .ignore support plugin (hsz.mobi)
 
+.vscode/
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/munglinker/data_pool.py
+++ b/munglinker/data_pool.py
@@ -104,7 +104,7 @@ class PairwiseMungoDataPool(Dataset):
             patch = self.load_patch(image_index, mungo_from, mungo_to)
             patches_batch[i_entity] = patch
 
-            mungos_are_connected = mungo_to.objid in mungo_from.outlinks
+            mungos_are_connected = mungo_to.id in mungo_from.outlinks
             if mungos_are_connected:
                 targets[i_entity] = 1
 

--- a/munglinker/data_pool.py
+++ b/munglinker/data_pool.py
@@ -402,11 +402,11 @@ def __load_munglinker_data(mung_root: str, images_root: str,
         exclude_classes = {}
 
     all_mung_files = glob(mung_root + "/**/*.xml", recursive=True)
-    mung_files_in_this_split = [f for f in all_mung_files if os.path.splitext(os.path.basename(f))[0] in include_names]
+    mung_files_in_this_split = sorted([f for f in all_mung_files if os.path.splitext(os.path.basename(f))[0] in include_names])
 
     all_image_files = glob(images_root + "/**/*.png", recursive=True)
-    image_files_in_this_split = [f for f in all_image_files if
-                                 os.path.splitext(os.path.basename(f))[0] in include_names]
+    image_files_in_this_split = sorted([f for f in all_image_files if
+                                 os.path.splitext(os.path.basename(f))[0] in include_names])
 
     mungs = []
     images = []

--- a/munglinker/data_pool.py
+++ b/munglinker/data_pool.py
@@ -148,7 +148,7 @@ class PairwiseMungoDataPool(Dataset):
         number_of_samples = 0
         for mung_index, mung in enumerate(tqdm(self.mungs, desc="Loading MuNG-pairs")):
             object_pairs = self.get_all_neighboring_object_pairs(
-                mung.cropobjects,
+                mung.vertices,
                 max_object_distance=self.max_edge_length,
                 grammar=self.grammar)
             for (m_from, m_to) in object_pairs:


### PR DESCRIPTION
This PR fixes a bug in the current munglinker software based around the data loading procedure. The program stopped during execution with out-of-bounds errors for mung node masks. This was tracked down to the loading procedure where the for loop zipped the annotation and image files without previously sorting those. This caused annotations for one image file to be applied to another and hence caused out-of-bounds issues in those cases where resolution differences allowed for this to become evident.

Also a method name has been adjusted as this has been renamed in a different code base and caused the execution to fail.